### PR TITLE
Use default kubectl convention for loading kubeconfig.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ terraform-provider-k8s is a Terraform provider to manage Kubernetes resources.
 ## Install
 ```sh
 docker pull registry.rebelsoft.com/terraform-provider-k8s
-alias tf='docker run -v `pwd`/kubeconfig:/kubeconfig -v `pwd`:/docker -w /docker --rm -it registry.rebelsoft.com/terraform-provider-k8s terraform'
-alias tfextract='docker run -v `pwd`/kubeconfig:/kubeconfig -v `pwd`:/docker -w /docker --rm -it registry.rebelsoft.com/terraform-provider-k8s extractor'
-alias tfgenerate='docker run -v `pwd`/kubeconfig:/kubeconfig -v `pwd`:/docker -w /docker --rm -it registry.rebelsoft.com/terraform-provider-k8s generator'
+alias tf='docker run -v `pwd`/kubeconfig:/kubeconfig -e KUBECONFIG=/kubeconfig -v `pwd`:/docker -w /docker --rm -it registry.rebelsoft.com/terraform-provider-k8s terraform'
+alias tfextract='docker run -v `pwd`/kubeconfig:/kubeconfig -e KUBECONFIG=/kubeconfig -v `pwd`:/docker -w /docker --rm -it registry.rebelsoft.com/terraform-provider-k8s extractor'
+alias tfgenerate='docker run -v `pwd`/kubeconfig:/kubeconfig -e KUBECONFIG=/kubeconfig -v `pwd`:/docker -w /docker --rm -it registry.rebelsoft.com/terraform-provider-k8s generator'
 ```
 
 ## Init

--- a/k8s/k8sconfig.go
+++ b/k8s/k8sconfig.go
@@ -30,14 +30,7 @@ func K8SConfig_Singleton() *K8SConfig {
 }
 
 func newK8SConfig() *K8SConfig {
-	//todo: where is kubeconfig
-	kubeconfig := "/kubeconfig"
-	cacheDir := "/dev/shm/kube/http-cache"
-
-	RESTClientGetter := &genericclioptions.ConfigFlags{
-		KubeConfig: &kubeconfig,
-		CacheDir:   &cacheDir,
-	}
+	RESTClientGetter := genericclioptions.NewConfigFlags(true)
 	RESTMapper, err := RESTClientGetter.ToRESTMapper()
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
I found that it's currently not really possible to use the provider outside of docker since it looks directly at `/kubeconfig`. By using the default `kubectl` convention for finding kubeconfig, it can be used outside of docker without having to copy around credentials, while the docker container can continue to work as is by setting an environment variable to read from `/kubeconfig`.